### PR TITLE
Add autopep8 pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.6.0
+    hooks:
+      - id: autopep8
+        args: ["--in-place", "--aggressive", "--aggressive"]

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,4 +1,6 @@
 import unittest
+
+
 class PlaceholderTest(unittest.TestCase):
     def test_pass(self):
         self.assertTrue(True)


### PR DESCRIPTION
## Summary
- configure pre-commit to run autopep8 with aggressive in-place formatting
- autoformat test suite using autopep8

## Testing
- `pre-commit run --all-files`
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_6854b412ec408332b697ec810426df9b