### PR TITLE
chore: add fix_flake8.sh for manual Flake8 auto-fixes

### DIFF
--- a/scripts/fix_flake8.sh
+++ b/scripts/fix_flake8.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "✨ Running auto-formatting for Flake8 compatibility..."
+
+# Ensure autopep8 is installed
+pip install autopep8
+
+# Run autopep8 recursively on src/ and tests/
+autopep8 --in-place --aggressive --aggressive --recursive src/
+autopep8 --in-place --aggressive --aggressive --recursive tests/
+
+echo "✅ Format complete. Re-run your commit or CI job!"


### PR DESCRIPTION
## Summary
Added a helper script `scripts/fix_flake8.sh` to automatically fix Flake8 linting issues across the codebase using autopep8.

This script is intended for manual cleanup of large files or bulk formatting before pushing, especially helpful for handling long lines, indentation, and trailing whitespace.

## Usage
Run the script from the project root:
```bash
bash scripts/fix_flake8.sh